### PR TITLE
Avoid leaking styles between instances.

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ class Markdown extends React.Component {
   }
 
   renderContent = () => {
-    const mergedStyles = Object.assign(styles, this.props.styles)
+    const mergedStyles = _.merge({}, styles, this.props.styles)
     const rules = this.postProcessRules(
       _.merge(
         {},


### PR DESCRIPTION
Previously Object.assign in would modify the global default styles object.